### PR TITLE
更新終了の注意事項を追加

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,8 +1,39 @@
-import { render, screen } from '@testing-library/react';
-import App from './App';
+import { render, screen, within } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import App from "./App";
 
-test('renders learn react link', () => {
-  render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
-});
+jest.mock(
+  "csv-parse/browser/esm/sync",
+  () =>
+    jest.requireActual("../node_modules/csv-parse/dist/cjs/sync.cjs"),
+  { virtual: true }
+);
+
+test.each(["/", "/ranking"])(
+  "%s で更新終了の注意事項と公式情報へのリンクを表示する",
+  (initialEntry) => {
+    render(
+      <MemoryRouter initialEntries={[initialEntry]}>
+        <App />
+      </MemoryRouter>
+    );
+
+    const alert = screen.getByRole("alert");
+    expect(
+      within(alert).getByRole("heading", {
+        name: "このサイトは更新を終了しています",
+      })
+    ).toBeInTheDocument();
+    expect(alert).toHaveTextContent("2022年3月12日改正時点");
+    expect(alert).toHaveTextContent("現行の運賃・制度とは異なります");
+    expect(
+      within(alert).getByRole("link", { name: "JRE POINT特典" })
+    ).toHaveAttribute(
+      "href",
+      "https://www.jreast.co.jp/tokuten_ticket/"
+    );
+    expect(
+      within(alert).getByRole("link", { name: "旅客営業規則" })
+    ).toHaveAttribute("href", "https://www.jreast.co.jp/ryokaku/");
+  }
+);

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,39 +1,8 @@
-import { render, screen, within } from "@testing-library/react";
-import { MemoryRouter } from "react-router-dom";
-import App from "./App";
+import { render, screen } from '@testing-library/react';
+import App from './App';
 
-jest.mock(
-  "csv-parse/browser/esm/sync",
-  () =>
-    jest.requireActual("../node_modules/csv-parse/dist/cjs/sync.cjs"),
-  { virtual: true }
-);
-
-test.each(["/", "/ranking"])(
-  "%s で更新終了の注意事項と公式情報へのリンクを表示する",
-  (initialEntry) => {
-    render(
-      <MemoryRouter initialEntries={[initialEntry]}>
-        <App />
-      </MemoryRouter>
-    );
-
-    const alert = screen.getByRole("alert");
-    expect(
-      within(alert).getByRole("heading", {
-        name: "このサイトは更新を終了しています",
-      })
-    ).toBeInTheDocument();
-    expect(alert).toHaveTextContent("2022年3月12日改正時点");
-    expect(alert).toHaveTextContent("現行の運賃・制度とは異なります");
-    expect(
-      within(alert).getByRole("link", { name: "JRE POINT特典" })
-    ).toHaveAttribute(
-      "href",
-      "https://www.jreast.co.jp/tokuten_ticket/"
-    );
-    expect(
-      within(alert).getByRole("link", { name: "旅客営業規則" })
-    ).toHaveAttribute("href", "https://www.jreast.co.jp/ryokaku/");
-  }
-);
+test('renders learn react link', () => {
+  render(<App />);
+  const linkElement = screen.getByText(/learn react/i);
+  expect(linkElement).toBeInTheDocument();
+});

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2629,7 +2629,32 @@ const App: React.VFC = () => {
       </Navbar>
       <Container>
         <Alert variant="warning" className="mt-3">
-          このページに表示される運賃・特急料金およびその他の内容について、正確性を保証しません。
+          <h2 className="alert-heading h4">
+            このサイトは更新を終了しています
+          </h2>
+          <p>
+            このサイトの掲載内容・計算結果は、2022年3月12日改正時点の情報をもとにしており、その後の運賃改定、旅客営業規則、JRE
+            POINT特典チケットの交換ポイントなどの変更は反映していません。掲載内容は、現行の運賃・制度とは異なります。正確性を保証しないため、参考資料としてのみご覧ください。
+          </p>
+          <p className="mb-0">
+            きっぷの購入や旅行の判断には使用せず、最新情報はJR東日本の
+            <a
+              href="https://www.jreast.co.jp/tokuten_ticket/"
+              target="_blank"
+              rel="noreferrer"
+            >
+              JRE POINT特典
+            </a>
+            および
+            <a
+              href="https://www.jreast.co.jp/ryokaku/"
+              target="_blank"
+              rel="noreferrer"
+            >
+              旅客営業規則
+            </a>
+            をご確認ください。
+          </p>
         </Alert>
         <div className="mt-4">
           <Routes>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2632,28 +2632,9 @@ const App: React.VFC = () => {
           <h2 className="alert-heading h4">
             このサイトは更新を終了しています
           </h2>
-          <p>
-            このサイトの掲載内容・計算結果は、2022年3月12日改正時点の情報をもとにしており、その後の運賃改定、旅客営業規則、JRE
-            POINT特典チケットの交換ポイントなどの変更は反映していません。掲載内容は、現行の運賃・制度とは異なります。正確性を保証しないため、参考資料としてのみご覧ください。
-          </p>
           <p className="mb-0">
-            きっぷの購入や旅行の判断には使用せず、最新情報はJR東日本の
-            <a
-              href="https://www.jreast.co.jp/tokuten_ticket/"
-              target="_blank"
-              rel="noreferrer"
-            >
-              JRE POINT特典
-            </a>
-            および
-            <a
-              href="https://www.jreast.co.jp/ryokaku/"
-              target="_blank"
-              rel="noreferrer"
-            >
-              旅客営業規則
-            </a>
-            をご確認ください。
+            このサイトの掲載内容・計算結果は、2022年3月12日改正時点の情報をもとにしており、その後の運賃改定、旅客営業規則、JRE
+            POINT特典チケットの交換ポイントなどの変更は反映していません。掲載内容は、現行の運賃・制度とは異なります。正確性を保証しません。最新の情報はご自身でお調べください。
           </p>
         </Alert>
         <div className="mt-4">


### PR DESCRIPTION
## 概要

公開中の計算ページが2022年3月12日改正時点の情報をもとにしたまま、現行の運賃・制度と異なる状態になっているため、全ページ共通の注意事項を具体化します。

## 変更内容

- サイトの更新が終了していることを見出しで明示
- 2022年3月12日改正時点の情報であり、現行の運賃・制度とは異なることを明記
- 正確性を保証せず、最新情報は利用者自身で調べるよう案内

## 変更しない範囲

運賃・ポイント・ランキングの計算ロジック、ページタイトル、検索設定、ルーティング、テストは変更していません。

## 検証

- production build: 成功