### PR TITLE
注意事項表記を強化

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -91,8 +91,10 @@ select { width: 100%; border: 0; border-bottom: 1px solid #94a198; background: t
 .ranking-table td strong { display: block; }
 .ranking-table .selected-rate { color: #087a52; font-size: 18px; }
 
-.notice { margin: 28px 0 56px; }
-.notice p { margin: 0; color: #65746b; font-size: 12px; line-height: 1.7; }
+.notice { margin: 24px 0 0; padding: 18px 20px; border-left: 4px solid #ff5a35; background: #fff2e9; }
+.notice h2 { margin: 0 0 8px; font-size: 16px; }
+.notice p { margin: 0; color: #6a5b51; font-size: 14px; line-height: 1.8; }
+.notice a { color: #13231d; font-weight: 700; text-underline-offset: 2px; }
 @media (max-width: 820px) {
   .control-bar, .dashboard-grid { grid-template-columns: 1fr; }
   .journey-fields, .journey-fields.has-direction { grid-template-columns: 1fr; }

--- a/src/App.test.ts
+++ b/src/App.test.ts
@@ -20,4 +20,21 @@ describe("区間入力画面", () => {
     expect(html).not.toContain("はやぶさ・こまち利用区間 始点");
     expect(html).not.toContain("グリーン車を利用する区間 始点");
   });
+
+  it("条件入力前に免責事項と確認先を表示する", () => {
+    const html = renderToStaticMarkup(createElement(App));
+
+    expect(html).toContain("ご利用上の注意");
+    expect(html).toContain("非公式の計算ツール");
+    expect(html).toContain("計算結果の正確性・完全性を保証するものではなく");
+    expect(html).toContain("公式の最新情報をご確認ください");
+    expect(html).toContain("時刻表・列車編成・残席・発売可否は判定しません");
+    expect(html).toContain("https://www.jreast.co.jp/ryokaku/");
+    expect(html).toContain("https://www.eki-net.com/top/product/shinkansen/e-tokuten.html");
+
+    const noticeIndex = html.indexOf('class="notice"');
+    const controlsIndex = html.indexOf('class="control-bar"');
+    expect(noticeIndex).toBeGreaterThan(-1);
+    expect(controlsIndex).toBeGreaterThan(noticeIndex);
+  });
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -319,6 +319,17 @@ const App = () => {
           </button>
         </nav>
 
+        <aside className="notice" aria-labelledby="notice-heading">
+          <h2 id="notice-heading">ご利用上の注意</h2>
+          <p>
+            本サイトはJR東日本・えきねっとの公式サービスではない、非公式の計算ツールです。計算結果の正確性・完全性を保証するものではなく、運賃・料金・交換ポイント等は変更される場合があります。実際の予約・購入前に、
+            <a href="https://www.jreast.co.jp/ryokaku/" target="_blank" rel="noreferrer">JR東日本の旅客営業規則</a>
+            および
+            <a href="https://www.eki-net.com/top/product/shinkansen/e-tokuten.html" target="_blank" rel="noreferrer">えきねっとの商品ページ</a>
+            など、公式の最新情報をご確認ください。時刻表・列車編成・残席・発売可否は判定しません。
+          </p>
+        </aside>
+
         <section className="control-bar">
           <label>交換レート
             <select value={campaign} onChange={(event) => onCampaignChange(event.target.value as Campaign)}>
@@ -591,9 +602,6 @@ const App = () => {
           </section>
         )}
 
-        <aside className="notice">
-          <p>時刻表・列車編成・残席・発売可否は判定しません。最新情報はご自身でお調べください。</p>
-        </aside>
       </main>
     </div>
   );


### PR DESCRIPTION
## 変更内容

PR #31で、従来の画面上部の警告がページ下部の小さな注意書きへ置き換わり、計算結果の正確性に関する注意と視認性が弱くなっていました。

- 「ご利用上の注意」をタブ直下へ移動し、区間画面とランキングの両方で条件入力前に表示
- 非公式ツールであること、正確性・完全性を保証しないこと、制度変更の可能性を明記
- JR東日本の旅客営業規則とえきねっとの商品ページを公式確認先として案内
- 淡い警告背景、左ボーダー、見出しを設けて視認性を改善
- 表示内容と配置を維持する回帰テストを追加

## 変更しない範囲

計算ロジック、比較軸、入力可能区間、運賃・料金・交換ポイントのデータ、README、設計方針は変更していません。

## 検証

- `npm run typecheck`
- `npm test`（76テスト成功）
- `npm run build`
- デスクトップ表示で注意枠が初期表示内に収まることを確認
- モバイル幅で横スクロールが発生せず、タブ直下に表示されることを確認